### PR TITLE
Added support for updatedBy in data-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "surix-sdk-monorepo",
   "private": true,
-  "version: "0.0.1",
   "devDependencies": {
     "lerna": "^3.4.3"
   },

--- a/packages/data-helpers/src/entity-wrapper/entity-wrapper.ts
+++ b/packages/data-helpers/src/entity-wrapper/entity-wrapper.ts
@@ -46,6 +46,10 @@ export class EntityWrapper implements WrappedEntity {
     return this._entity.createdBy;
   }
 
+  get updatedBy (): AuthContext {
+    return this._entity.updatedBy;
+  }
+
   get (fieldPath: string | FieldPathArray, defaultValue?: any): any {
     const pathArray = normalizeFieldPath(fieldPath);
     return this._value(pathArray, defaultValue);
@@ -61,12 +65,6 @@ export class EntityWrapper implements WrappedEntity {
     const field = walkEntityPath(this._entity, pathArray);
     return field ? field.type : defaultType;
   }
-
-  label (fieldPath: string | FieldPathArray, defaultLabel?: string): string|undefined {
-    const pathArray = normalizeFieldPath(fieldPath);
-    const field = walkEntityPath(this._entity, pathArray) as Field;
-    return field && field.label ? field.label : defaultLabel;
-  } 
 
   field (fieldPath: string | FieldPathArray, defaultField?: FieldOrValuePair):
   NullableFieldOrValuePair {

--- a/packages/data-helpers/src/entity-wrapper/tests/__snapshots__/entity-wrapper.test.ts.snap
+++ b/packages/data-helpers/src/entity-wrapper/tests/__snapshots__/entity-wrapper.test.ts.snap
@@ -34,8 +34,6 @@ Object {
 
 exports[`EntityWrapper field should return the raw field (list of landmarks) 1`] = `
 Object {
-  "label": "Landmarks",
-  "name": "landmarks",
   "type": "list",
   "value": Array [
     Object {
@@ -48,8 +46,6 @@ Object {
 
 exports[`EntityWrapper field when a default is provided should return the true (list of landmarks) field if the the path is matched 1`] = `
 Object {
-  "label": "Landmarks",
-  "name": "landmarks",
   "type": "list",
   "value": Array [
     Object {
@@ -86,25 +82,17 @@ Array [
       },
       "data": Object {
         "active": Object {
-          "label": "Active",
-          "name": "active",
           "type": "boolean",
           "value": false,
         },
         "address": Object {
-          "label": "Address",
-          "name": "address",
           "type": "object",
           "value": Object {
             "city": Object {
-              "label": "City",
-              "name": "city",
               "type": "text",
               "value": "Nairobi",
             },
             "landmarks": Object {
-              "label": "Landmarks",
-              "name": "landmarks",
               "type": "list",
               "value": Array [
                 Object {
@@ -114,22 +102,16 @@ Array [
               ],
             },
             "street": Object {
-              "label": "Street",
-              "name": "street",
               "type": "text",
               "value": "Some street",
             },
           },
         },
         "count": Object {
-          "label": "Count",
-          "name": "count",
           "type": "number",
           "value": "100",
         },
         "image": Object {
-          "label": "Image",
-          "name": "image",
           "type": "file",
           "value": Object {
             "downloadUrl": "download",
@@ -138,14 +120,10 @@ Array [
           },
         },
         "lastSeen": Object {
-          "label": "Last seen",
-          "name": "lastSeen",
           "type": "datetime",
           "value": "2018-11-22T09:19:33.885Z",
         },
         "misc": Object {
-          "label": "Misc",
-          "name": "misc",
           "type": "list",
           "value": Array [
             Object {
@@ -164,8 +142,6 @@ Array [
               "type": "object",
               "value": Object {
                 "foo": Object {
-                  "label": "Foo",
-                  "name": "foo",
                   "type": "text",
                   "value": "bar",
                 },
@@ -174,8 +150,6 @@ Array [
           ],
         },
         "title": Object {
-          "label": "Title",
-          "name": "title",
           "type": "text",
           "value": "My Title",
         },
@@ -185,6 +159,10 @@ Array [
         "stuff",
       ],
       "updatedAt": "2018-10-22T09:19:33.885Z",
+      "updatedBy": Object {
+        "_id": "user2",
+        "type": "user",
+      },
     },
     Array [
       "address",

--- a/packages/data-helpers/src/entity-wrapper/tests/__snapshots__/wrap-entity.test.ts.snap
+++ b/packages/data-helpers/src/entity-wrapper/tests/__snapshots__/wrap-entity.test.ts.snap
@@ -11,8 +11,6 @@ EntityWrapper {
     },
     "data": Object {
       "name": Object {
-        "label": "Name",
-        "name": "name",
         "type": "text",
         "value": "Foo",
       },
@@ -22,6 +20,10 @@ EntityWrapper {
       "t2",
     ],
     "updatedAt": "2018-10-22T09:19:33.885Z",
+    "updatedBy": Object {
+      "_id": "u2",
+      "type": "user",
+    },
   },
   "createdAt": 2017-02-22T09:19:33.885Z,
   "updatedAt": 2018-10-22T09:19:33.885Z,
@@ -40,8 +42,6 @@ Array [
       },
       "data": Object {
         "name": Object {
-          "label": "Name",
-          "name": "name",
           "type": "text",
           "value": "Foo",
         },
@@ -51,6 +51,10 @@ Array [
         "t2",
       ],
       "updatedAt": "2018-10-22T09:19:33.885Z",
+      "updatedBy": Object {
+        "_id": "u2",
+        "type": "user",
+      },
     },
     "createdAt": 2017-02-22T09:19:33.885Z,
     "updatedAt": 2018-10-22T09:19:33.885Z,
@@ -65,8 +69,6 @@ Array [
       },
       "data": Object {
         "name": Object {
-          "label": "Name",
-          "name": "name",
           "type": "text",
           "value": "Bar",
         },
@@ -76,6 +78,10 @@ Array [
         "t2",
       ],
       "updatedAt": "2018-10-23T09:19:33.885Z",
+      "updatedBy": Object {
+        "_id": "u3",
+        "type": "user",
+      },
     },
     "createdAt": 2017-02-23T09:19:33.885Z,
     "updatedAt": 2018-10-23T09:19:33.885Z,

--- a/packages/data-helpers/src/entity-wrapper/tests/entity-wrapper.test.ts
+++ b/packages/data-helpers/src/entity-wrapper/tests/entity-wrapper.test.ts
@@ -10,22 +10,22 @@ describe('EntityWrapper', () => {
     entity = {
       _id: 'entity1',
       data: {
-        title: util.makeField('My Title', 'text', 'title', 'Title'),
-        active: util.makeField(false, 'boolean', 'active', 'Active'),
-        count: util.makeField('100', 'number', 'count', 'Count'),
+        title: util.makeField('My Title', 'text'),
+        active: util.makeField(false, 'boolean'),
+        count: util.makeField('100', 'number'),
         address: util.makeField({
-          city: util.makeField('Nairobi', 'text', 'city', 'City'),
-          street: util.makeField('Some street', 'text', 'street', 'Street'),
+          city: util.makeField('Nairobi', 'text'),
+          street: util.makeField('Some street', 'text'),
           landmarks: util.makeField([
             { type: 'text', value: 'Near historical monument' }
-          ], 'list', 'landmarks', 'Landmarks')
-        }, 'object', 'address', 'Address'),
-        lastSeen: util.makeField('2018-11-22T09:19:33.885Z', 'datetime', 'lastSeen', 'Last seen'),
+          ], 'list')
+        }, 'object'),
+        lastSeen: util.makeField('2018-11-22T09:19:33.885Z', 'datetime'),
         image: util.makeField({
           ref: 'file1',
           mimeType: 'image/jpeg',
           downloadUrl: 'download'
-        }, 'file', 'image', 'Image'),
+        }, 'file'),
         misc: util.makeField([
           {
             type: 'file',
@@ -37,14 +37,18 @@ describe('EntityWrapper', () => {
           },
           { type: 'number', value: '223.45' },
           { type: 'object', value: {
-            foo: util.makeField('bar', 'text', 'foo', 'Foo')
+            foo: util.makeField('bar', 'text')
           }}
-        ], 'list', 'misc', 'Misc')
+        ], 'list',)
       },
       createdAt: '2017-02-22T09:19:33.885Z',
       updatedAt: '2018-10-22T09:19:33.885Z',
       createdBy: {
         _id: 'user1',
+        type: 'user'
+      },
+      updatedBy: {
+        _id: 'user2',
         type: 'user'
       },
       tags: ['posts', 'stuff']
@@ -58,6 +62,7 @@ describe('EntityWrapper', () => {
       expect(wrapped.id).toEqual(entity._id);
       expect(wrapped.tags).toEqual(entity.tags);
       expect(wrapped.createdBy).toEqual(entity.createdBy);
+      expect(wrapped.updatedBy).toEqual(entity.updatedBy);
     });
     it('should return timestamps properties converted to Date objects', () => {
       expect(wrapped.createdAt).toEqual(new Date(entity.createdAt));
@@ -190,43 +195,14 @@ describe('EntityWrapper', () => {
     });
     describe('when a default is provided', () => {
       it('should return the default if the path cannot be matched', () => {
-        const defField = util.makeField('test', 'text', 'name', 'label');
+        const defField = util.makeField('test', 'text');
         const field = wrapped.field('address.unknown.landmarks', defField);
         expect(field).toEqual(defField);
       });
       it('should return the true (list of landmarks) field if the the path is matched', () => {
-        const defField = util.makeField('test', 'text', 'name', 'label');
+        const defField = util.makeField('test', 'text');
         const field = wrapped.field('address.landmarks', defField);
         expect(field).toMatchSnapshot();
-      });
-    });
-  });
-
-  describe('label', () => {
-    it('should return the label of the field at the specified path', () => {
-      const label = wrapped.label('address.landmarks');
-      expect(label).toEqual('Landmarks');
-    });
-    it('should return undefined if the field at the path does not have a label', () => {
-      const label = wrapped.label('address.landmarks.0');
-      expect(label).toBeUndefined();
-    });
-    it('should return undefined if the path cannot be matched', () => {
-      const label = wrapped.label('address.unknown.landmarks');
-      expect(label).toBeUndefined();
-    });
-    describe('when a default is provided', () => {
-      it('should return the default if the path cannot be matched', () => {
-        const label = wrapped.label('address.unknown.landmarks', 'Label');
-        expect(label).toBe('Label');
-      });
-      it('should return the default if the field at the path does not have a label', () => {
-        const label = wrapped.label('address.landmarks.0', 'Label');
-        expect(label).toBe('Label');
-      });
-      it('should return the true label if the the path is matched', () => {
-        const label = wrapped.label('address.landmarks', 'boolean');
-        expect(label).toBe('Landmarks');
       });
     });
   });

--- a/packages/data-helpers/src/entity-wrapper/tests/wrap-entity.test.ts
+++ b/packages/data-helpers/src/entity-wrapper/tests/wrap-entity.test.ts
@@ -8,10 +8,14 @@ describe('wrapEntity', () => {
     const entity: ApiEntity = {
       _id: 'ent1',
       data: {
-        name: util.makeField('Foo', 'text', 'name', 'Name')
+        name: util.makeField('Foo', 'text')
       },
       createdBy: {
         _id: 'u1',
+        type: 'user'
+      },
+      updatedBy: {
+        _id: 'u2',
         type: 'user'
       },
       createdAt: '2017-02-22T09:19:33.885Z',
@@ -29,10 +33,14 @@ describe('wrapEntityArray', () => {
       {
         _id: 'ent1',
         data: {
-          name: util.makeField('Foo', 'text', 'name', 'Name')
+          name: util.makeField('Foo', 'text')
         },
         createdBy: {
           _id: 'u1',
+          type: 'user'
+        },
+        updatedBy: {
+          _id: 'u2',
           type: 'user'
         },
         createdAt: '2017-02-22T09:19:33.885Z',
@@ -42,10 +50,14 @@ describe('wrapEntityArray', () => {
       {
         _id: 'ent2',
         data: {
-          name: util.makeField('Bar', 'text', 'name', 'Name')
+          name: util.makeField('Bar', 'text')
         },
         createdBy: {
           _id: 'u2',
+          type: 'user'
+        },
+        updatedBy: {
+          _id: 'u3',
           type: 'user'
         },
         createdAt: '2017-02-23T09:19:33.885Z',

--- a/packages/data-helpers/src/types.ts
+++ b/packages/data-helpers/src/types.ts
@@ -33,8 +33,6 @@ export interface ObjectValue {
 }
 
 export interface Field extends TypeValuePair {
-    name: string;
-    label: string;
 }
 
 export interface TypeValuePair {

--- a/packages/data-helpers/src/types.ts
+++ b/packages/data-helpers/src/types.ts
@@ -4,6 +4,7 @@ export class ApiEntity {
     updatedAt: string;
     data: ObjectValue;
     createdBy: AuthContext;
+    updatedBy: AuthContext;
     tags: string[];
 }
 
@@ -43,7 +44,7 @@ export interface TypeValuePair {
 
 export interface AuthContext {
     _id: string;
-    type: 'user' | 'app' | 'localapp';
+    type: 'user' | 'app';
 }
 
 export type FieldOrValuePair = Field | TypeValuePair;
@@ -72,6 +73,10 @@ export interface WrappedEntity {
      */
     createdBy: AuthContext;
     /**
+     * user or app that updated the entity;
+     */
+    updatedBy: AuthContext;
+    /**
      * list of tags the entity belongs to
      */
     tags: string[];
@@ -95,14 +100,6 @@ export interface WrappedEntity {
      * @param defaultType the type to return if the entity does not have the field
      */
     type (fieldPath: string | FieldPathArray, defaultType?: FieldType): FieldType|undefined;
-    /**
-     * returns the label of the field with the specified key
-     * @param fieldPath the key of the field, this can be a
-     * dotted string "field.nestedField" or an array ["field", "nestedField"]
-     * the path can include field names as well as array indices
-     * @param defaultLabel the label to return if the field does not exist
-     */
-    label (fieldPath: string | FieldPathArray, defaultLabel?: string): string|undefined;
     /**
      * returns the raw field at the specified key
      * @param fieldPath the key of the field, this can be a

--- a/packages/data-helpers/src/util/tests/__snapshots__/util.test.ts.snap
+++ b/packages/data-helpers/src/util/tests/__snapshots__/util.test.ts.snap
@@ -34,8 +34,6 @@ Object {
 
 exports[`util walkEntityPath should call walkFieldPath with the first field (returns dar field) 1`] = `
 Object {
-  "label": "Dar",
-  "name": "dar",
   "type": "text",
   "value": "dar value",
 }
@@ -43,8 +41,6 @@ Object {
 
 exports[`util walkFieldPath when the start field has type object should return nested field (fizz) at the specified path 1`] = `
 Object {
-  "label": "Fizz",
-  "name": "fizz",
   "type": "text",
   "value": "buzz",
 }
@@ -52,8 +48,6 @@ Object {
 
 exports[`util walkFieldPath when the start field has type object should support array indices as ints (returns dar field) 1`] = `
 Object {
-  "label": "Dar",
-  "name": "dar",
   "type": "text",
   "value": "dar value",
 }
@@ -61,8 +55,6 @@ Object {
 
 exports[`util walkFieldPath when the start field has type object should walk through array indices and return dar field 1`] = `
 Object {
-  "label": "Dar",
-  "name": "dar",
   "type": "text",
   "value": "dar value",
 }
@@ -77,8 +69,6 @@ Object {
 
 exports[`util walkFieldPath when the start field is a list should return walk nested object and return dar field 1`] = `
 Object {
-  "label": "Dar",
-  "name": "dar",
   "type": "text",
   "value": "dar value",
 }

--- a/packages/data-helpers/src/util/tests/util.test.ts
+++ b/packages/data-helpers/src/util/tests/util.test.ts
@@ -5,10 +5,8 @@ import { ApiEntity, Field, ObjectValue } from '../../types';
 describe('util', () => {
   describe('makeField', () => {
     it('should create a field based on the give value and metadata', () => {
-      const field = util.makeField('value', 'text', 'name', 'Label');
+      const field = util.makeField('value', 'text');
       expect(field).toEqual({
-        name: 'name',
-        label: 'Label',
         type: 'text',
         value: 'value'
       });
@@ -50,13 +48,13 @@ describe('util', () => {
     describe('when value type is object', () => {
       it('should convert the value to plain object values without field metadata', () => {
         const value = {
-          title: util.makeField('My Title', 'text', 'title', 'Title'),
-          read: util.makeField(true, 'boolean', 'read', 'Read'),
+          title: util.makeField('My Title', 'text'),
+          read: util.makeField(true, 'boolean'),
           cover: util.makeField({
             ref: 'file1',
             mimeType: 'image/jpeg',
             downloadUrl: 'download1'
-          }, 'file', 'cover', 'Cover')
+          }, 'file')
         };
         expect(util.deflateValue(value, 'object')).toEqual({
           title: 'My Title',
@@ -89,15 +87,15 @@ describe('util', () => {
         const value = {
           foo: util.makeField({
             bar: util.makeField({
-              baz: util.makeField('abc', 'text', 'baz', 'Baz'),
-              baq: util.makeField('20', 'number', 'baq', 'Baq'),
-              buz: util.makeField(false, 'boolean', 'buz', 'Buz'),
-              bez: util.makeField('2018-02-22T09:19:33.885Z', 'datetime', 'bez', 'Bez'),
+              baz: util.makeField('abc', 'text'),
+              baq: util.makeField('20', 'number'),
+              buz: util.makeField(false, 'boolean'),
+              bez: util.makeField('2018-02-22T09:19:33.885Z', 'datetime'),
               bat: util.makeField(
                 { ref: 'f2', mimeType: 'image/png', downloadUrl: 'down1' },
-                'file', 'bat', 'Bat')
-            }, 'object', 'bar', 'Bar'),
-          },'object', 'foo', 'Foo'),
+                'file')
+            }, 'object'),
+          },'object'),
           biz: util.makeField([
             { type: 'boolean', value: true },
             { type: 'text', value: 'xyz' },
@@ -109,9 +107,9 @@ describe('util', () => {
               downloadUrl: 'down3'
             } },
             { type: 'object', value: {
-              fizz: util.makeField('buzz', 'text', 'fizz', 'Fizz' )
+              fizz: util.makeField('buzz', 'text')
             } }
-          ], 'list', 'biz', 'Biz')
+          ], 'list')
         };
         expect(util.deflateValue(value, 'object')).toMatchSnapshot();
       });
@@ -124,9 +122,9 @@ describe('util', () => {
     beforeEach(() => {
       objField = util.makeField({
         foo: util.makeField({
-          fizz: util.makeField('buzz', 'text', 'fizz', 'Fizz')
-        }, 'object', 'foo', 'Foo'),
-        bar: util.makeField('bar value', 'text', 'bar', 'Bar'),
+          fizz: util.makeField('buzz', 'text')
+        }, 'object'),
+        bar: util.makeField('bar value', 'text'),
         rabs: util.makeField([
           {
             type: 'boolean',
@@ -135,11 +133,11 @@ describe('util', () => {
           {
             type: 'object',
             value: {
-              dar: util.makeField('dar value', 'text', 'dar', 'Dar')
+              dar: util.makeField('dar value', 'text')
             }
           }
-        ], 'list', 'rabs', 'Rabs')
-      }, 'object', 'name', 'label');
+        ], 'list')
+      }, 'object');
     });
 
     describe('when the start field has type object', () => {
@@ -197,12 +195,16 @@ describe('util', () => {
           _id: 'u1',
           type: 'user'
         },
+        updatedBy: {
+          _id: 'u2',
+          type: 'user'
+        },
         tags: [],
         data: {
           foo: util.makeField({
-            fizz: util.makeField('buzz', 'text', 'fizz', 'Fizz')
-          }, 'object', 'foo', 'Foo'),
-          bar: util.makeField('bar value', 'text', 'bar', 'Bar'),
+            fizz: util.makeField('buzz', 'text')
+          }, 'object'),
+          bar: util.makeField('bar value', 'text'),
           rabs: util.makeField([
             {
               type: 'boolean',
@@ -211,10 +213,10 @@ describe('util', () => {
             {
               type: 'object',
               value: {
-                dar: util.makeField('dar value', 'text', 'dar', 'Dar')
+                dar: util.makeField('dar value', 'text')
               }
             }
-          ], 'list', 'rabs', 'Rabs')
+          ], 'list')
         }
       };
     });

--- a/packages/data-helpers/src/util/util.ts
+++ b/packages/data-helpers/src/util/util.ts
@@ -77,11 +77,9 @@ export function deflateList (list: ListValue): any[] {
   return list.map(({ type, value }) => deflateValue(value, type));
 }
 
-export function makeField (value: FieldValue, type: FieldType, name: string, label: string): Field {
+export function makeField (value: FieldValue, type: FieldType): Field {
   return {
     value,
-    type,
-    name,
-    label
+    type
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5671,7 +5671,7 @@ ts-loader@^5.3.0:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 


### PR DESCRIPTION
Added support for `updatedBy` in data-helpers. Also removed `label`s because they are no longer supported.

Example code: 

```typescript
import { Client, Project, WrappedEntity } from '@surix/client';

const client = new Client({ 
    baseUrl: 'http://localhost:5000/api',
    keyId: '2O6i1qqKuDzBzPWI2bK7fB',
    keySecret: 'iMpMqPAoEWKd9Ry531dJ5vyqz2dclzjh17NWJGYRLVaiE9OevnhErecXMhfDKfF5'
});

const project = client.project('2kTS597fekXFDXTWZZBUwg')

project.entities.query().then((entities: WrappedEntity[]) => {
    console.log(entities[0].updatedBy)
}).catch((error: any) => {
    console.log(error.response.data)
})
```

### Related issues
#12 