### PR TITLE
Adds delete and deleteMany on client

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -144,6 +144,30 @@ entities.forEach((entity) => {
 });
 ```
 
+#### `project.entities.delete(id: string)`
+
+Deletes an entity entirely.
+
+```javascript
+const entityId = 'someid';
+const deletedEntity = await project.entities.delete(entityId);
+
+console.log(deletedEntity.get('name') + ' was deleted');
+```
+
+#### `project.entities.deleteMany(ids: EntityIds)`
+
+Deletes a bunch of entities identified by the provided ids.
+
+```javascript
+const entitiesIds = {
+  entities: ['someid1', 'someid2']
+}
+
+const response = await project.entities.deleteMany(entitiesIds);
+console.log(response.deleted); // Number of deleted entities
+```
+
 ### Files
 
 #### `project.files.get(id: string)`

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -160,9 +160,7 @@ console.log(deletedEntity.get('name') + ' was deleted');
 Deletes a bunch of entities identified by the provided ids.
 
 ```javascript
-const entitiesIds = {
-  entities: ['someid1', 'someid2']
-}
+const entitiesIds = ['someid1', 'someid2'];
 
 const response = await project.entities.deleteMany(entitiesIds);
 console.log(response.deleted); // Number of deleted entities

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@surix/client",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Surix API Client",
   "keywords": [
     "surix",

--- a/packages/client/src/project/entities.ts
+++ b/packages/client/src/project/entities.ts
@@ -1,6 +1,6 @@
 import { ApiEntity,  expandEntity, wrapEntity, wrapEntityArray, WrappedEntity} from '@surix/data-helpers';
 import { AxiosInstance } from 'axios';
-import {  Entity, ProjectEntities, Query, EntityIds, DeletedEntities } from '../types';
+import {  DeletedEntities, Entity, ProjectEntities, Query } from '../types';
 
 export function getProjectEntities (projectId: string, apiClient: AxiosInstance): ProjectEntities {
   return {
@@ -38,10 +38,12 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
       const returnedEntity = res.data;
       return wrapEntity(returnedEntity);
     },
-    async deleteMany(entityIds: EntityIds): Promise<DeletedEntities> {
+    async deleteMany(entityIds: string[]): Promise<DeletedEntities> {
       const res = await apiClient.delete(`/projects/${projectId}/entities`, 
       {
-        data: entityIds 
+        data: {
+          entities: entityIds
+        }
       });
       return res.data;
     },

--- a/packages/client/src/project/entities.ts
+++ b/packages/client/src/project/entities.ts
@@ -1,6 +1,6 @@
 import { ApiEntity,  expandEntity, wrapEntity, wrapEntityArray, WrappedEntity} from '@surix/data-helpers';
 import { AxiosInstance } from 'axios';
-import {  Entity, ProjectEntities, Query } from '../types';
+import {  Entity, ProjectEntities, Query, EntityIds, DeletedEntities } from '../types';
 
 export function getProjectEntities (projectId: string, apiClient: AxiosInstance): ProjectEntities {
   return {
@@ -32,6 +32,18 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
         `/projects/${projectId}/entities/${entityId}`, expandedEntity);
       const returnedEntity = res.data;
       return wrapEntity(returnedEntity);
+    },
+    async delete(entityId: string): Promise<WrappedEntity> {
+      const res = await apiClient.delete(`/projects/${projectId}/entities/${entityId}`);
+      const returnedEntity = res.data;
+      return wrapEntity(returnedEntity);
+    },
+    async deleteMany(entityIds: EntityIds): Promise<DeletedEntities> {
+      const res = await apiClient.delete(`/projects/${projectId}/entities`, 
+      {
+        data: entityIds 
+      });
+      return res.data;
     },
     async create(entity: Entity): Promise<WrappedEntity> {
       const expandedEntity = expandEntity(entity);

--- a/packages/client/src/project/tests/__snapshots__/files.test.ts.snap
+++ b/packages/client/src/project/tests/__snapshots__/files.test.ts.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Project Files get should return the wrapped file 1`] = `
+Object {
+  "_id": "f1",
+  "createdAt": 2017-02-22T09:19:33.885Z,
+  "createdBy": Object {
+    "_id": "u1",
+    "type": "user",
+  },
+  "downloadUrl": "http://download/f1",
+  "filename": "f1.jpeg",
+  "id": "f1",
+  "mimeType": "image/jpeg",
+  "name": "F1",
+  "public": true,
+  "rawFile": Object {
+    "_id": "f1",
+    "createdAt": "2017-02-22T09:19:33.885Z",
+    "createdBy": Object {
+      "_id": "u1",
+      "type": "user",
+    },
+    "downloadUrl": "http://download/f1",
+    "filename": "f1.jpeg",
+    "mimeType": "image/jpeg",
+    "name": "F1",
+    "public": true,
+    "size": 200,
+    "status": "ready",
+    "tags": Array [
+      "t1",
+    ],
+    "updatedAt": "2018-10-22T09:19:33.885Z",
+    "uploadUrl": "http://upload/f1",
+  },
+  "size": 200,
+  "status": "ready",
+  "tags": Array [
+    "t1",
+  ],
+  "updatedAt": 2018-10-22T09:19:33.885Z,
+  "uploadUrl": "http://upload/f1",
+}
+`;
+
+exports[`Project Files list should return the wrapped file array 1`] = `
+Array [
+  Object {
+    "_id": "f1",
+    "createdAt": 2017-02-22T09:19:33.885Z,
+    "createdBy": Object {
+      "_id": "u1",
+      "type": "user",
+    },
+    "downloadUrl": "http://download/f1",
+    "filename": "f1.jpeg",
+    "id": "f1",
+    "mimeType": "image/jpeg",
+    "name": "F1",
+    "public": true,
+    "rawFile": Object {
+      "_id": "f1",
+      "createdAt": "2017-02-22T09:19:33.885Z",
+      "createdBy": Object {
+        "_id": "u1",
+        "type": "user",
+      },
+      "downloadUrl": "http://download/f1",
+      "filename": "f1.jpeg",
+      "mimeType": "image/jpeg",
+      "name": "F1",
+      "public": true,
+      "size": 200,
+      "status": "ready",
+      "tags": Array [
+        "t1",
+      ],
+      "updatedAt": "2018-10-22T09:19:33.885Z",
+      "uploadUrl": "http://upload/f1",
+    },
+    "size": 200,
+    "status": "ready",
+    "tags": Array [
+      "t1",
+    ],
+    "updatedAt": 2018-10-22T09:19:33.885Z,
+    "uploadUrl": "http://upload/f1",
+  },
+  Object {
+    "_id": "f2",
+    "createdAt": 2017-02-22T09:19:33.885Z,
+    "createdBy": Object {
+      "_id": "u1",
+      "type": "user",
+    },
+    "downloadUrl": "",
+    "filename": "f2.jpeg",
+    "id": "f2",
+    "mimeType": "image/jpeg",
+    "name": "F2",
+    "public": true,
+    "rawFile": Object {
+      "_id": "f2",
+      "createdAt": "2017-02-22T09:19:33.885Z",
+      "createdBy": Object {
+        "_id": "u1",
+        "type": "user",
+      },
+      "downloadUrl": "",
+      "filename": "f2.jpeg",
+      "mimeType": "image/jpeg",
+      "name": "F2",
+      "public": true,
+      "size": 0,
+      "status": "pending",
+      "tags": Array [
+        "t1",
+      ],
+      "updatedAt": "2018-10-22T09:19:33.885Z",
+      "uploadUrl": "http://upload/f1",
+    },
+    "size": 0,
+    "status": "pending",
+    "tags": Array [
+      "t1",
+    ],
+    "updatedAt": 2018-10-22T09:19:33.885Z,
+    "uploadUrl": "http://upload/f1",
+  },
+]
+`;

--- a/packages/client/src/project/tests/__snapshots__/tags.test.ts.snap
+++ b/packages/client/src/project/tests/__snapshots__/tags.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Project tags list should return tags list 1`] = `
+Array [
+  Object {
+    "name": "posts",
+  },
+  Object {
+    "name": "users",
+  },
+]
+`;

--- a/packages/client/src/project/tests/entities.test.ts
+++ b/packages/client/src/project/tests/entities.test.ts
@@ -3,7 +3,7 @@ import { AxiosInstance } from 'axios';
 import * as api from '../../api';
 import { getProjectApi } from '../project';
 
-import { Query, EntityIds, DeletedEntities } from '../../types';
+import { DeletedEntities, Query } from '../../types';
 
 describe('Project Entities', () => {
   const apiEntities = [
@@ -177,10 +177,10 @@ describe('Project Entities', () => {
           return ent;
         }
 
-        async function callMockDeleteMany (entityIds: EntityIds): Promise<DeletedEntities> {
+        async function callMockDeleteMany (entityIds: string[]): Promise<DeletedEntities> {
           apiClient = api.getApiClient('http://baseurl', 'somekey');
           jest.spyOn(apiClient, 'delete').mockReturnValue(Promise.resolve({ data: 
-            { deleted: entityIds.entities.length } }));
+            { deleted: entityIds.length } }));
           jest.spyOn(dataHelpers, 'wrapEntity');
           const project = getProjectApi('project1', apiClient);
           const ent = await project.entities.deleteMany(entityIds);
@@ -193,13 +193,11 @@ describe('Project Entities', () => {
           expect(apiClient.delete).toHaveBeenCalledWith(`/projects/project1/entities/${entityId}`);
         });
         it('should call DELETE /projects/:pid/entities with a list of entity ids', async () => {
-          const entityIds = {
-            entities: ['entity1', 'entity2']
-          };
+          const entityIds = ['entity1', 'entity2'];
 
           await callMockDeleteMany(entityIds);
           expect(apiClient.delete).toHaveBeenCalledWith(`/projects/project1/entities`, 
-          { data: entityIds });
+          { data: { entities: entityIds } });
         });
       });
   }); 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -46,12 +46,9 @@ export interface ProjectEntities {
    * Deletes a bunch of entities that have the provided IDs
    * @param {EntityIds} entityIds A list of IDs
    */
-  deleteMany(entityIds: EntityIds): Promise<DeletedEntities>;
+  deleteMany(entityIds: string[]): Promise<DeletedEntities>;
 }
 
-export interface EntityIds {
-  entities: string[];
-}
 export interface DeletedEntities {
   deleted: number;
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -7,13 +7,54 @@ export interface Project {
 }
 
 export interface ProjectEntities {
+  /**
+   * Fetches an entity with the given id
+   * @param id An ID indetifying an entity
+   * @returns {Promise<WrappedEntity>}
+   */
   get(id: string): Promise<WrappedEntity>;
+  /**
+   * Fetches entities based on the provided query
+   * @param query A query to be used to fetch entities
+   * @returns {Promise<WrappedEntity[]>}
+   */
   query(query?: Query): Promise<WrappedEntity[]>;
+  /**
+   * Creates and saves the provided entity
+   * @param {Entity} entity An entity
+   * @returns {Promise<WrappedEntity>}
+   */
   create(entity: Entity): Promise<WrappedEntity>;
+  /**
+   * Updates the entity identified by the _id property provided.
+   * @param {Entity} entity An entity
+   * @returns {Promise<WrappedEntity>}
+   */
   update(entity: Entity): Promise<WrappedEntity>;
+  /**
+   * Replaces the entity identified by the _id property provided.
+   * @param {Entity} entity An entity
+   * @returns {Promise<WrappedEntity>}
+   */
   put(entity: Entity): Promise<WrappedEntity>;
+  /**
+   * Completely removes an etity identified by the id provided.
+   * @param {string} entityId An ID
+   */
+  delete(entityId: string): Promise<WrappedEntity>;
+  /**
+   * Deletes a bunch of entities that have the provided IDs
+   * @param {EntityIds} entityIds A list of IDs
+   */
+  deleteMany(entityIds: EntityIds): Promise<DeletedEntities>;
 }
 
+export interface EntityIds {
+  entities: string[];
+}
+export interface DeletedEntities {
+  deleted: number;
+}
 export interface ProjectFiles {
   get(id: string): Promise<WrappedFile>;
   list(): Promise<WrappedFile[]>;


### PR DESCRIPTION
### Usage
#### `delete`
```javascript
const entityId = 'someid';
const deletedEntity = await project.entities.delete(entityId);

console.log(deletedEntity.get('name') + ' was deleted');
```

#### `deleteMany`
```javascript
const entitiesIds = {
  entities: ['someid1', 'someid2']
}

const response = await project.entities.deleteMany(entitiesIds);
console.log(response.deleted); // Number of deleted entities
```
### Relates issues
#20 