### PR TITLE
Fixed incorrectly expanded array values

### DIFF
--- a/packages/data-helpers/README.md
+++ b/packages/data-helpers/README.md
@@ -39,8 +39,7 @@ const {
 
 ### `expandEntity`
 
-Converts a user friendly version of an entity to the raw version of the entity.  
-*Note: For now, dates are interpreted `text` type but will be updated to `datatime` in future*
+Converts a user friendly version of an entity to the raw version of the entity.
 ```javascript
 import { expandEntity } from '@surix/data-helpers';
 
@@ -66,6 +65,14 @@ const expandedEntity = expandEntity(entity);
 
 **Note:** `Date()` will be converted to a string. `new Date()` will be converted to `datetime` so if you want dated treated correctly, you can use `new Date()`
 
+### `expandArray`
+
+Converts a user friendly version if an array to a raw array.
+```javascript
+const { expandArray } from '@surix/data-helpers';
+const array = [ 1, 2, 3, { name: 'My name' }];
+const expandedArray = expandArray(array)
+```
 ### `wrapEntity`
 
 ```javascript

--- a/packages/data-helpers/src/expand-entity/expand-entity.ts
+++ b/packages/data-helpers/src/expand-entity/expand-entity.ts
@@ -95,5 +95,6 @@ function expandArrayValue(value: any[]): any[] {
 }
 
 export {
-    expandEntity
+    expandEntity,
+    expandArrayValue
 };

--- a/packages/data-helpers/src/expand-entity/index.ts
+++ b/packages/data-helpers/src/expand-entity/index.ts
@@ -1,1 +1,1 @@
-export { expandEntity } from './expand-entity';
+export { expandEntity, expandArrayValue as expandArray } from './expand-entity';

--- a/packages/data-helpers/src/expand-entity/tests/__snapshots__/expand-entity.test.ts.snap
+++ b/packages/data-helpers/src/expand-entity/tests/__snapshots__/expand-entity.test.ts.snap
@@ -46,6 +46,23 @@ Object {
       "type": "text",
       "value": "Kevin Nderitu",
     },
+    "petsAges": Object {
+      "type": "list",
+      "value": Array [
+        Object {
+          "type": "number",
+          "value": 1,
+        },
+        Object {
+          "type": "number",
+          "value": 2,
+        },
+        Object {
+          "type": "number",
+          "value": 4,
+        },
+      ],
+    },
   },
   "tags": Array [
     "sometag",

--- a/packages/data-helpers/src/expand-entity/tests/expand-entity.test.ts
+++ b/packages/data-helpers/src/expand-entity/tests/expand-entity.test.ts
@@ -20,13 +20,15 @@ describe('ExpandEntity', () => {
                         name: 'Second daughter'
                     }
                 ],
+                petsAges: [1, 2, 4],
                 isOldEnough: true
             },
             tags: ['sometag'],
             _id: 'thisisanid'
         };
     });
+  
     it('should convert successfully', async () => {
-        expect(expandEntity(entity)).toMatchSnapshot()
+        expect(expandEntity(entity)).toMatchSnapshot();
     });
 });

--- a/packages/data-helpers/src/index.ts
+++ b/packages/data-helpers/src/index.ts
@@ -16,5 +16,6 @@ export {
 } from './types';
 
 export {
-  expandEntity
+  expandEntity,
+  expandArray
 } from './expand-entity';


### PR DESCRIPTION
The following:
```js
import { expandEntity } from '@surix/data-helpers';
const entity = {
    data: {
        numbers: [1, 2, 3, 4, { name: 'Kevin' }, 'string', true, [1], new Date() ]
    }
};
const expanded = expandEntity(entity);
console.log(expanded.data.numbers.value);
```
Would log:
```js
[ 
    { type: 'number', value: 1 },
    { type: 'number', value: 2 },
    { type: 'number', value: 3 },
    { type: 'number', value: 4 },
    {  
        name: { type: 'text', value: 'Kevin' } 
    },
    { type: 'text', value: 'string' },
    { type: 'boolean', value: true },
    [ 
        { type: 'number', value: 1 } 
    ],
    { type: 'datetime', value: '2019-06-15T15:59:54.496Z' } 
]
```

### Related issue
#25 