### PR TITLE
Added expandQuery function

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -73,9 +73,9 @@ The entity above would be converted to:
 Dates are expanded as `text` for now and will correctly be expanded to `datetime` in future versions of `@surix/data-helpers`. Arrays are not supported for now.
 
 
-#### `project.entities.patch(entity: Entity)`
+#### `project.entities.update(entity: Entity)`
 
-Updates a entity partially. I.e adds onto the already existing entity identified by the `_id` field.
+Updates an entity partially. I.e adds onto the already existing entity identified by the `_id` field.
 
 ```javascript
 const entity = {
@@ -86,7 +86,7 @@ const entity = {
   tags: ['tag']
 }
 
-const updatedEntity = await project.entities.patch(entity);
+const updatedEntity = await project.entities.update(entity);
 ```
 
  Dates created with the `Date()` function are expanded as `text`. and those created with `new Date()` are correctly expanded to `datetime`.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -62,7 +62,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@surix/data-helpers": "^0.7.1",
+    "@surix/data-helpers": "^0.7.2",
     "axios": "^0.18.0"
   }
 }

--- a/packages/data-helpers/package.json
+++ b/packages/data-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@surix/data-helpers",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Utilities for making it easy to work with Surix data",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/data-helpers/src/index.ts
+++ b/packages/data-helpers/src/index.ts
@@ -19,3 +19,7 @@ export {
   expandEntity,
   expandArray
 } from './expand-entity';
+
+export {
+  expandQuery
+} from './util';

--- a/packages/data-helpers/src/util/index.ts
+++ b/packages/data-helpers/src/util/index.ts
@@ -3,5 +3,6 @@ export {
   makeField,
   toFieldPathArray,
   walkEntityPath,
-  walkFieldPath
+  walkFieldPath,
+  expandQuery
 } from './util';

--- a/packages/data-helpers/src/util/tests/__snapshots__/util.test.ts.snap
+++ b/packages/data-helpers/src/util/tests/__snapshots__/util.test.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`util Expand query Dates should expand regex successfully 1`] = `
+Object {
+  "limit": 100,
+  "query": Object {
+    "$or": Array [
+      Object {
+        "time": Object {
+          "$gt": Object {
+            "$treatAsDatetime": "2019-06-18T20:55:26.711Z",
+          },
+        },
+      },
+      Object {
+        "age": Object {
+          "$lt": Object {
+            "$treatAsDatetime": "2019-06-18T20:55:26.711Z",
+          },
+        },
+      },
+    ],
+    "name": "Me myself",
+  },
+  "skip": 2,
+}
+`;
+
+exports[`util Expand query Regex should expand regex successfully 1`] = `
+Object {
+  "limit": 100,
+  "query": Object {
+    "name": "Me myself",
+    "title": Object {
+      "$options": "i",
+      "$regex": "/developer/i",
+    },
+  },
+  "skip": 2,
+}
+`;
+
 exports[`util deflateValue when value is complex nested object should recursively convert value to plain object without field metadata 1`] = `
 Object {
   "biz": Array [

--- a/packages/data-helpers/src/util/tests/util.test.ts
+++ b/packages/data-helpers/src/util/tests/util.test.ts
@@ -237,4 +237,42 @@ describe('util', () => {
       });
     });
   });
+
+  describe('Expand query', () => {
+    describe('Regex', () => {
+      let query;
+      beforeAll(async () => {
+        query = {
+          query: {
+            name: 'Me myself',
+            title: /developer/i
+          },
+          limit: 100,
+          skip: 2
+        };
+      });
+      it('should expand regex successfully', async () => {
+        expect(util.expandQuery(query)).toMatchSnapshot();
+      });
+    });
+    describe('Dates', () => {
+      let query;
+      beforeAll(async () => {
+        query = {
+          query: {
+            name: 'Me myself',
+            $or: [
+              { time: { $gt: new Date() }},
+              { age: { $lt: new Date() }}
+            ]
+          },
+          limit: 100,
+          skip: 2
+        };
+      });
+      it('should expand regex successfully', async () => {
+        expect(util.expandQuery(query)).toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
       "declaration": true,
       "importHelpers": true,
       "lib": [
-        "es2015",
+        "es2015", "es2017.object",
         "dom"
       ],
       "module": "commonjs",


### PR DESCRIPTION
Added expandQuery function that converts dates and regular expressions

Example (regular expressions):
```js
const q = {
    query: {
        name: /^Steve/i
    }
};

const expandedQ = expandQuery(q);
```
Would result to:
```js
{
    query: {
        name: { $regex: '/^Steve/i', $options: 'i' }
    }
}
```
Example (dates):
```js
const q = {
    query: {
        age: {
            $gt: new Date()
        }
    }
};

const expandedQ = expandQuery(q);
```
Would result to:
```js
{
    query: {
        age: {
            $gt: {
                $treatAsDatetime: 'Date ISO String'
            }
        }
    }
}
```
### Related issue
#23 