### PR TITLE
Points to mvp endpoint 

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -9,24 +9,25 @@ const { Client } = require('@surix/client');
 
 import { Client } from '@surix/client';
 ```
-
+Or on the browser:
+```html
+<script src="https://cdn.jsdelivr.net/npm/@surix/client@[version]/dist/client.min.js"></script>
+<!-- Replace version with an actual version number -->
+```
 Create Client instance:
 
 ```javascript
-const client = new Client();
-```
-
-Create Client for the server
-
-Use custom base URL
-
-```javascript
 const client = new Client({ 
-  environment: 'staging', // staging or production
-  baseUrl: 'https://mydomain.com/api', // custom server
   keyId: 'key id provided by surix',
   keySecret: 'key secret provided by surix'
   });
+```
+Or on the browser:
+```js
+const client = new Surix.Client({
+  keyId: 'key id provided by surix',
+  keySecret: 'key secret provided by surix'
+});
 ```
 
 Note: `keyId` and `keySecret` are provided in the surix dashboard, under account settings.

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1,14 +1,11 @@
+import { AxiosInstance } from 'axios';
 import { getApiClient } from '../api';
 import { getProjectApi } from '../project';
 import { Project } from '../types';
-import { AxiosInstance } from 'axios';
 
-export const PRODUCTION_URL = 'https://api.surix.co/api';
-export const STAGING_URL = 'https://surix-staging.herokuapp.com/api';
+export const PRODUCTION_URL = 'https://surix-review3.herokuapp.com/api';
 
 export interface ClientOptions {
-  environment?: 'production' | 'staging';
-  baseUrl?: string;
   keyId: string;
   keySecret: string;
 }
@@ -17,14 +14,9 @@ export class Client {
   private _apiClient: AxiosInstance;
 
   constructor (opts: ClientOptions) {
-    const _opts: ClientOptions = Object.assign({
-      environment: 'production',
-      baseUrl: ''
-    }, opts);
-    let baseUrl = _opts.environment === 'production' ? PRODUCTION_URL : STAGING_URL;
-    baseUrl = _opts.baseUrl || baseUrl;
+    const _opts = { ...opts };
     const apiKey = `${_opts.keyId}:${_opts.keySecret}`;
-    this._apiClient = getApiClient(baseUrl, apiKey);
+    this._apiClient = getApiClient(PRODUCTION_URL, apiKey);
   }
 
   project (id: string): Project {

--- a/packages/client/src/client/test/__snapshots__/client.test.ts.snap
+++ b/packages/client/src/client/test/__snapshots__/client.test.ts.snap
@@ -1,27 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Client new instance should create http client based on production Surix API url 1`] = `
+exports[`Client new instance should create http client based MVP url 1`] = `
 Array [
   Array [
-    "https://api.surix.co/api",
-    "someid:somesecret",
-  ],
-]
-`;
-
-exports[`Client new instance should override baseUrl if baseUrl option is provided 1`] = `
-Array [
-  Array [
-    "http://mydomain.com/api",
-    "someid:somesecret",
-  ],
-]
-`;
-
-exports[`Client new instance when environment is not set to production should create http client based on staging url 1`] = `
-Array [
-  Array [
-    "https://surix-staging.herokuapp.com/api",
+    "https://surix-review3.herokuapp.com/api",
     "someid:somesecret",
   ],
 ]

--- a/packages/client/src/client/test/client.test.ts
+++ b/packages/client/src/client/test/client.test.ts
@@ -6,27 +6,12 @@ describe('Client', () => {
   const authKey = {
     keyId: 'someid',
     keySecret: 'somesecret'
-  }
+  };
 
   describe('new instance', () => {
-    it('should create http client based on production Surix API url', () => {
+    it('should create http client based MVP url', () => {
       const spy = jest.spyOn(api, 'getApiClient');
       new Client({ ...authKey });
-      expect(spy.mock.calls).toMatchSnapshot();
-      spy.mockRestore();
-    });
-    describe('when environment is not set to production', () => {
-      it('should create http client based on staging url', () => {
-        const spy = jest.spyOn(api, 'getApiClient');
-        new Client({ environment: 'staging', ...authKey });
-        expect(spy.mock.calls).toMatchSnapshot();
-        spy.mockRestore();
-      });
-    });
-    it('should override baseUrl if baseUrl option is provided', () => {
-      const spy = jest.spyOn(api, 'getApiClient');
-      const baseUrl = 'http://mydomain.com/api';
-      new Client({ baseUrl, ...authKey });
       expect(spy.mock.calls).toMatchSnapshot();
       spy.mockRestore();
     });

--- a/packages/client/src/project/entities.ts
+++ b/packages/client/src/project/entities.ts
@@ -17,6 +17,9 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
     },
     async query(query: Query = {}): Promise<WrappedEntity[]> {
       const expandedQuery = expandQuery(query);
+      if (Object.keys(expandedQuery.query).length === 0) {
+        delete expandedQuery.query;
+      }
       const res = await apiClient.post<ApiEntity[]>(
         `/projects/${projectId}/entities/query`, expandedQuery);
       const entities = res.data;

--- a/packages/client/src/project/tests/entities.test.ts
+++ b/packages/client/src/project/tests/entities.test.ts
@@ -83,7 +83,7 @@ describe('Project Entities', () => {
       it('should call query endpoint with empty object', async () => {
         await callMockedQuery();
         expect(apiClient.post).toHaveBeenCalledWith(`/projects/project1/entities/query`, 
-        { query: {} });
+        {});
       });
     });
   }); 


### PR DESCRIPTION
Pointed to https://surix-review3.herokuapp.com/api
Now to create an instance of a client
```js
import { Client } from '@surix/client`;

const client: Client = new Client({
    keyId: 'key id',
    keySecret: 'key secret'
});
```
The SDK will use the MVP endpoint https://surix-review3.herokuapp.com/api

### Related issue
#30 


While I was at it, I fixed a bug with the `expandQuery` which returns an empty object if query is empty.
For example, if we have a query:
```js
const query = {
    limit: 10
}
```
`expandQuery` would return:
```js
{
    query: {},
    limit: 10
}
```
I just checked if query is empty, if it is, `delete`d it