### PR TITLE
Add tags support

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -166,6 +166,31 @@ const response = await project.entities.deleteMany(entitiesIds);
 console.log(response.deleted); // Number of deleted entities
 ```
 
+#### `project.entities.addTags(entityId: string, tags: string | string[])`
+
+Adds tags to an entity identified by the  `entityId` provided
+
+```javascript
+const entityId = 'someid';
+const entity = project.entities.addTags(entityId, 'new-tag'); // A single tag
+
+const entity = project.entities.addTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
+
+// Returns the updated entity
+```
+
+#### `project.entities.removeTags(entityId: string, tags: string | string[])`
+
+Removes tags from the entity identified by the  `entityId` provided
+
+```javascript
+const entityId = 'someid';
+const entity = project.entities.removeTags(entityId, 'new-tag'); // A single tag
+
+const entity = project.entities.removeTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
+
+// Returns the updated entity
+```
 ### Files
 
 #### `project.files.get(id: string)`
@@ -195,4 +220,13 @@ Fetches all tags in project.
 ```javascript
 const tags = await project.tags.list();
 tags.forEach((tag) => console.log(tag.name));
+```
+
+#### `project.tags.rename(oldName: string, newName: string)`
+
+Renames a tag from `oldName` to `newName`
+
+```javascript
+const tag = await project.tags.rename('oldName', 'newName');
+console.log(tag.name) // Should be newName
 ```

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -172,9 +172,9 @@ Adds tags to an entity identified by the  `entityId` provided
 
 ```javascript
 const entityId = 'someid';
-const entity = project.entities.addTags(entityId, 'new-tag'); // A single tag
+const entity = await project.entities.addTags(entityId, 'new-tag'); // A single tag
 
-const entity = project.entities.addTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
+const entity = await project.entities.addTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
 
 // Returns the updated entity
 ```
@@ -185,9 +185,9 @@ Removes tags from the entity identified by the  `entityId` provided
 
 ```javascript
 const entityId = 'someid';
-const entity = project.entities.removeTags(entityId, 'new-tag'); // A single tag
+const entity = await project.entities.removeTags(entityId, 'new-tag'); // A single tag
 
-const entity = project.entities.removeTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
+const entity = await project.entities.removeTags(entityId, ['new-tag', 'another-tag']); // Multiple tags
 
 // Returns the updated entity
 ```
@@ -207,7 +207,7 @@ console.log(file.downloadUrl);
 Fetches all files in the project.
 
 ```javascript
-const files = await.project.files.list();
+const files = await project.files.list();
 files.forEach((file) => console.log(file.downloadUrl));
 ```
 

--- a/packages/client/src/project/entities.ts
+++ b/packages/client/src/project/entities.ts
@@ -7,7 +7,7 @@ import {
   WrappedEntity
 } from '@surix/data-helpers';
 import { AxiosInstance } from 'axios';
-import {  DeletedEntities, Entity, ProjectEntities, Query } from '../types';
+import {  DeletedEntities, Entity, ProjectEntities, Query, TagList } from '../types';
 
 export function getProjectEntities (projectId: string, apiClient: AxiosInstance): ProjectEntities {
   return {
@@ -60,6 +60,44 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
       const expandedEntity = expandEntity(entity);
       const res = await apiClient.post<ApiEntity>(
         `/projects/${projectId}/entities`, expandedEntity);
+      const returnedEntity = res.data;
+      return wrapEntity(returnedEntity);
+    },
+
+    // Tags
+
+    async addTags(entityId: string, tags: string[]): Promise<WrappedEntity> {
+      let _tags: string[] = [];
+      if(typeof tags === 'string') {
+        _tags = Array.from([tags]);
+      } else {
+        _tags = Array.from(tags);
+      }
+      const res = await apiClient.put<ApiEntity>(
+        `/projects/${projectId}/entities/${entityId}/tags`,
+        {
+          tags: _tags
+        }
+      );
+      const returnedEntity = res.data;
+      return wrapEntity(returnedEntity);
+    },
+
+    async removeTags(entityId: string, tags: string[]): Promise<WrappedEntity> {
+      let _tags: string[] = [];
+      if(typeof tags === 'string') {
+        _tags = Array.from([tags]);
+      } else {
+        _tags = Array.from(tags);
+      }
+      const res = await apiClient.delete(
+        `/projects/${projectId}/entities/${entityId}/tags`,
+        {
+          data: {
+            tags: _tags
+          }
+        }
+      );
       const returnedEntity = res.data;
       return wrapEntity(returnedEntity);
     }

--- a/packages/client/src/project/entities.ts
+++ b/packages/client/src/project/entities.ts
@@ -67,12 +67,7 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
     // Tags
 
     async addTags(entityId: string, tags: string[]): Promise<WrappedEntity> {
-      let _tags: string[] = [];
-      if(typeof tags === 'string') {
-        _tags = Array.from([tags]);
-      } else {
-        _tags = Array.from(tags);
-      }
+      const _tags: string[] = Array.isArray(tags)? tags: Array.from([tags]);
       const res = await apiClient.put<ApiEntity>(
         `/projects/${projectId}/entities/${entityId}/tags`,
         {
@@ -84,12 +79,7 @@ export function getProjectEntities (projectId: string, apiClient: AxiosInstance)
     },
 
     async removeTags(entityId: string, tags: string[]): Promise<WrappedEntity> {
-      let _tags: string[] = [];
-      if(typeof tags === 'string') {
-        _tags = Array.from([tags]);
-      } else {
-        _tags = Array.from(tags);
-      }
+      const _tags: string[] =  Array.isArray(tags)? tags: Array.from([tags]);
       const res = await apiClient.delete(
         `/projects/${projectId}/entities/${entityId}/tags`,
         {

--- a/packages/client/src/project/tags.ts
+++ b/packages/client/src/project/tags.ts
@@ -1,10 +1,16 @@
 import { AxiosInstance } from 'axios';
-import { ProjectTags, TagList  } from '../types';
+import { ProjectTags, Tag, TagList  } from '../types';
 
 export function getProjectTags (projectId: string, apiClient: AxiosInstance): ProjectTags {
   return {
     async list (): Promise<TagList> {
       const res = await apiClient.get<TagList>(`/projects/${projectId}/tags`);
+      return res.data;
+    }, 
+    async rename (oldName: string, newName: string): Promise<Tag> {
+      const res = await apiClient.put<Tag>(`/projects/${projectId}/tags/${oldName}`, {
+        name: newName
+      });
       return res.data;
     }
   };

--- a/packages/client/src/project/tests/__snapshots__/tags.test.ts.snap
+++ b/packages/client/src/project/tests/__snapshots__/tags.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Project tags Rename should return the nre tag 1`] = `
+Object {
+  "name": "newName",
+}
+`;
+
 exports[`Project tags list should return tags list 1`] = `
 Array [
   Object {

--- a/packages/client/src/project/tests/entities.test.ts
+++ b/packages/client/src/project/tests/entities.test.ts
@@ -210,4 +210,72 @@ describe('Project Entities', () => {
       { data: { entities: entityIds } });
     });
   });
+  describe('addTags', () => {
+    let apiClient: AxiosInstance;
+    async function callMockAddTags (entityId: string, tags: string | string[]): 
+    Promise<dataHelpers.WrappedEntity> {
+      apiClient = api.getApiClient('someid', 'somekey');
+      jest.spyOn(apiClient, 'put').mockReturnValue(Promise.resolve({ data: 
+        { ...apiEntities[0] } }));
+      jest.spyOn(dataHelpers, 'wrapEntity');
+      const project = getProjectApi('project1', apiClient);
+      const ent = await project.entities.addTags(entityId, tags);
+      return ent;
+    }
+    it('should call PUT /projects/:pid/entities/:eid/tags', async () => {
+      const tags = ['tag1', 'tag2'];
+      await callMockAddTags('entity1', tags);
+      expect(apiClient.put).toHaveBeenCalledWith(
+        `/projects/project1/entities/entity1/tags`,
+        {
+          tags
+        }
+      );
+    });
+    it('should call PUT /projects/:pid/entities/:eid/tags with array when given a string', 
+    async () => {
+      const tags = 'tag1';
+      await callMockAddTags('entity1', tags);
+      expect(apiClient.put).toHaveBeenCalledWith(
+        `/projects/project1/entities/entity1/tags`,
+        {
+          tags: [tags]
+        }
+      );
+    });
+  });
+  describe('removeTags', () => {
+    let apiClient: AxiosInstance;
+    async function callMockAddTags (entityId: string, tags: string | string[]): 
+    Promise<dataHelpers.WrappedEntity> {
+      apiClient = api.getApiClient('someid', 'somekey');
+      jest.spyOn(apiClient, 'delete').mockReturnValue(Promise.resolve({ data: 
+        { ...apiEntities[0] } }));
+      jest.spyOn(dataHelpers, 'wrapEntity');
+      const project = getProjectApi('project1', apiClient);
+      const ent = await project.entities.removeTags(entityId, tags);
+      return ent;
+    }
+    it('should call DELETE /projects/:pid/entities/:eid/tags', async () => {
+      const tags = ['tag1', 'tag2'];
+      await callMockAddTags('entity1', tags);
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        `/projects/project1/entities/entity1/tags`,
+        {
+          data: {tags}
+        }
+      );
+    });
+    it('should call DELETE /projects/:pid/entities/:eid/tags with array when given a string', 
+    async () => {
+      const tags = 'tag1';
+      await callMockAddTags('entity1', tags);
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        `/projects/project1/entities/entity1/tags`,
+        {
+          data: { tags: [tags] }
+        }
+      );
+    });
+  });
 });

--- a/packages/client/src/project/tests/tags.test.ts
+++ b/packages/client/src/project/tests/tags.test.ts
@@ -1,6 +1,7 @@
 import * as dataHelpers from '@surix/data-helpers';
 import { AxiosInstance } from 'axios';
 import * as api from '../../api';
+import { Tag } from '../../types';
 import { getProjectApi } from '../project';
 
 describe('Project tags', () => {
@@ -28,5 +29,30 @@ describe('Project tags', () => {
       const tags = await callMockedList();
       expect(tags).toMatchSnapshot();
      });
+  });
+  describe('Rename', () => {
+    let apiClient: AxiosInstance;
+    let newTag = {
+      name: 'newName'
+    }
+    function callMockedRename(): Promise<Tag> {
+      apiClient = api.getApiClient('someid', 'somekey');
+      jest.spyOn(apiClient, 'put').mockReturnValue(
+        Promise.resolve({ data: newTag })
+      );
+      const project = getProjectApi('project1', apiClient);
+      return project.tags.rename('oldName', 'newName');
+    }
+    it('should call projects/:pid/tags/:oldName endpoint', async () => {
+      await callMockedRename();
+      expect(apiClient.put).toHaveBeenCalledWith(
+        '/projects/project1/tags/oldName',
+        { name: 'newName' }
+      );
+    });
+    it('should return the nre tag', async () => {
+      const tag = await callMockedRename();
+      expect(tag).toMatchSnapshot();
+    });
   });
 });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -47,6 +47,18 @@ export interface ProjectEntities {
    * @param {EntityIds} entityIds A list of IDs
    */
   deleteMany(entityIds: string[]): Promise<DeletedEntities>;
+  /**
+   * Adds tags onto an entity
+   * @param id an ID representing an Entity
+   * @param tags A single tag or multiple tag IDs
+   */
+  addTags(id: string, tags: string | string[]): Promise<WrappedEntity>;
+  /**
+   * Removes tags from an entity
+   * @param id an ID representing an Entity
+   * @param tags A single tag or multiple tag IDs
+   */
+  removeTags(id: string, tags: string | string[]): Promise<WrappedEntity>;
 }
 
 export interface DeletedEntities {
@@ -59,6 +71,8 @@ export interface ProjectFiles {
 
 export interface ProjectTags {
   list(): Promise<TagList>;
+  rename(oldName: string, newName: string): Promise<Tag>;
+
 }
 
 export interface Query {
@@ -115,3 +129,4 @@ export interface Entity {
   tags?: string[];
   _id?: string;
 }
+export type Tag = TagListItem;


### PR DESCRIPTION
### Added tags as proposed on the related issue.
 However I went ahead and added an option to allow users to supply a string as the second param on `addTags` and `removeTags` to add or remove just one tag
```javascript
const entity = await project.entities.addTags('entity1`, 'another-tag');
// Is equivalent to
const entity = await project.entities.addTags('entity1`, ['another-tag']);
```
Same applies to `removeTags`

### Related issues
#28 